### PR TITLE
Use ExtendEditorLogsComponent instead of webtaskWidget

### DIFF
--- a/build/bundle.js
+++ b/build/bundle.js
@@ -177,7 +177,8 @@ var logsTemplate = s(function () {/*
     <link rel="shortcut icon" href="https://cdn.auth0.com/styleguide/2.0.1/lib/logos/img/favicon.png" />
     <link rel="stylesheet" type="text/css" href="https://cdn.auth0.com/manage/v0.3.973/css/index.min.css" />
     <link rel="stylesheet" type="text/css" href="https://cdn.auth0.com/styleguide/3.1.6/index.css">
-    <script src="https://cdn.auth0.com/webtaskWidget/auth0-webtask-widget-2.0.min.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://cdn.auth0.com/webtask-editor/styles/1/wt-editor.min.css">
+    <script type="text/javascript" src="https://cdn.auth0.com/auth0-extend/develop/components/extend-editor-logs.js"></script>
     <script type="text/javascript" src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
     <script type="text/javascript" src="https://fb.me/react-0.14.0.min.js"></script>
     <script type="text/javascript" src="https://fb.me/react-dom-0.14.0.js"></script>
@@ -193,7 +194,7 @@ var logsTemplate = s(function () {/*
           flex-direction: column;
           padding-bottom: 0;
         }
-        ​
+
         .header {
           flex: 0 0 100px;
         }
@@ -226,6 +227,10 @@ var logsTemplate = s(function () {/*
           line-height: 71px;
           border-radius: 3px;
           text-align: center;
+        }
+
+        .wt-close {
+          display: none;
         }
     </style>
     <script type="text/javascript">
@@ -284,12 +289,11 @@ var logsTemplate = s(function () {/*
     <div class="message"><div>Press ESC to exit full screen mode</div></div>
     <div id="widget_container" class="logs"></div>
     <script>
-    	var logs = webtaskWidget.showLogs({
-			mount: document.getElementById('widget_container'),
-			url: '<%- webtaskAPIUrl %>',
-			token: '<%- token %>',
-			container: '<%- container %>'
-    	});
+      ExtendEditorLogsComponent.show(document.getElementById('widget_container'), {
+        token: '<%- token %>',
+        hostUrl: '<%- webtaskAPIUrl %>',
+        theme: 'dark'
+      });
 
       $('.js-full-screen').on('click', function () {
         $('.dashboard-header').hide();

--- a/build/bundle.js
+++ b/build/bundle.js
@@ -178,7 +178,7 @@ var logsTemplate = s(function () {/*
     <link rel="stylesheet" type="text/css" href="https://cdn.auth0.com/manage/v0.3.973/css/index.min.css" />
     <link rel="stylesheet" type="text/css" href="https://cdn.auth0.com/styleguide/3.1.6/index.css">
     <link rel="stylesheet" type="text/css" href="https://cdn.auth0.com/webtask-editor/styles/1/wt-editor.min.css">
-    <script type="text/javascript" src="https://cdn.auth0.com/auth0-extend/develop/components/extend-editor-logs.js"></script>
+    <script type="text/javascript" src="https://cdn.auth0.com/auth0-extend/components/1/extend-editor-logs.js"></script>
     <script type="text/javascript" src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
     <script type="text/javascript" src="https://fb.me/react-0.14.0.min.js"></script>
     <script type="text/javascript" src="https://fb.me/react-dom-0.14.0.js"></script>

--- a/build/bundle.js
+++ b/build/bundle.js
@@ -108,7 +108,7 @@ app.get('/meta', function (req, res) {
     res.json({
       "title": "Real-time Webtask Logs",
       "name": "auth0-extension-realtime-logs",
-      "version": "1.0.3",
+      "version": "1.3.0",
       "author": "Auth0, Inc",
       "description": "Access real-time webtask logs",
       "type": "application",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-extension-realtime-logs",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Access real-time webtask logs",
   "scripts": {
     "deploy": "wt create ./build/bundle.js --name logs --no-parse --no-merge"

--- a/webtask.json
+++ b/webtask.json
@@ -1,10 +1,11 @@
 {
   "title": "Real-time Webtask Logs",
   "name": "auth0-extension-realtime-logs",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": "Auth0, Inc",
   "description": "Access real-time webtask logs",
   "type": "application",
+  "repository": "https://github.com/auth0/auth0-extension-realtime-logs",
   "keywords": [
     "auth0",
     "extension",


### PR DESCRIPTION
## ✏️ Changes

Use [ExtendEditorLogsComponent](https://github.com/auth0/extend-editor/tree/develop/packages/logs-viewer) instead of [webtaskWidget](https://github.com/auth0/webtask-Widget). WebtaskWidget has long been deprecated. Extend Editor is the way of the future!

## 📷 Screenshots

### Chrome
![image](https://user-images.githubusercontent.com/947526/41919744-39a3d0ee-792d-11e8-9419-e4f80f02da6b.png)

### Edge
![edge](https://www.evernote.com/shard/s285/sh/c3b50bd1-a4ef-401b-be49-4de944117da4/35ec362923d0e07d/res/7b139adc-6c0a-4e6e-b768-def3b310bdf4/skitch.png)

## 🔗 References

Zendesk - https://auth0.zendesk.com/agent/tickets/42913

## 🎯 Testing

✅ This has been tested locally
✅ This has been tested in a webtask
✅This change has unit test coverage
✅This change has been acceptance tested
✅This change has been manually smoke tested

## 🚀 Deployment

🚫 This change can support multiple releases of the code serving traffic at the same time
✅ This can be deployed any time because it has no prerequisites.

## 🎡 Rollout

✅ The change will be available to the complete environment at once
🚫 The change is behind a feature flag and will go through a percentage based rollout process
🚫 The change is behind a flag and customers will opt-in to the change

In order to verify that the deployment was successful we will update the extensions via a test tenant and perform smoke tests to ensure proper execution.

## 🔥 Rollback

We will rollback if:
- the smoke test fails
- we receive a customer ticket indicating we broke the extension

### 📄 Procedure

A code revert+redeploy can be done to revert the change.

## 🖥 Appliance

✅ This change is compatible with the appliance.