### PR TITLE
KEY-172 Add missing metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-extension-realtime-logs",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Access real-time webtask logs",
   "scripts": {
     "deploy": "wt create ./build/bundle.js --name logs --no-parse --no-merge"

--- a/webtask.json
+++ b/webtask.json
@@ -6,6 +6,7 @@
   "description": "Access real-time webtask logs",
   "type": "application",
   "repository": "https://github.com/auth0/auth0-extension-realtime-logs",
+  "docsUrl": "https://auth0.com/docs/extensions/realtime-webtask-logs",
   "keywords": [
     "auth0",
     "extension",

--- a/webtask.json
+++ b/webtask.json
@@ -1,7 +1,8 @@
 {
   "title": "Real-time Webtask Logs",
   "name": "auth0-extension-realtime-logs",
-  "version": "1.3.1",
+  "version": "1.3.2",
+  "preVersion": "1.3.2",
   "author": "Auth0, Inc",
   "description": "Access real-time webtask logs",
   "type": "application",


### PR DESCRIPTION
Extension should contain links to documentation and repository.

Story: https://auth0team.atlassian.net/browse/KEY-172