### PR TITLE
Add missing logoUrl to extension metadata

### DIFF
--- a/webtask.json
+++ b/webtask.json
@@ -8,6 +8,7 @@
   "type": "application",
   "repository": "https://github.com/auth0/auth0-extension-realtime-logs",
   "docsUrl": "https://auth0.com/docs/extensions/realtime-webtask-logs",
+  "logoUrl": "https://cdn.auth0.com/extensions/auth0-extension-realtime-logs/assets/logo.svg",
   "keywords": [
     "auth0",
     "extension",


### PR DESCRIPTION
### Description

Add missing `logoUrl` to the extension metadata. See https://github.com/auth0/auth0-extensions/pull/355